### PR TITLE
Remove print statement

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -937,8 +937,6 @@ class QdrantClient:
             wal_config=wal_config
         )
 
-        print(json.dumps(create_collection_request.dict(), indent=2))
-
         self.http.collections_api.create_collection(
             collection_name=collection_name,
             create_collection=create_collection_request,


### PR DESCRIPTION
The current version displays the request body while trying to recreate the collection. That breaks the stdout content.