### PR TITLE
[WIP] propagate client kwargs to batchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 .idea
 .coverage
 htmlcov
+*.iml
+dist

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,6 +321,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "nest-asyncio"
+version = "1.5.5"
+description = "Patch asyncio to allow nested event loops"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "numpy"
 version = "1.21.1"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -694,7 +702,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "a431bf5a79018b08aa3afee7ce112f936b85d0dcb87588b35cbb415db917acef"
+content-hash = "1f92404f605fb28d62afe53dc4c1bfeeed61e9992a5293b673bfc321ee8ef74d"
 
 [metadata.files]
 alabaster = [
@@ -1028,6 +1036,10 @@ multidict = [
     {file = "multidict-6.0.2-cp39-cp39-win32.whl", hash = "sha256:23b616fdc3c74c9fe01d76ce0d1ce872d2d396d8fa8e4899398ad64fb5aa214a"},
     {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
     {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
+]
+nest-asyncio = [
+    {file = "nest_asyncio-1.5.5-py3-none-any.whl", hash = "sha256:b98e3ec1b246135e4642eceffa5a6c23a3ab12c82ff816a92c612d68205813b2"},
+    {file = "nest_asyncio-1.5.5.tar.gz", hash = "sha256:e442291cd942698be619823a17a86a5759eabe1f8613084790de189fe9e16d65"},
 ]
 numpy = [
     {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ loguru = "^0.5.3"
 typing-extensions = "^4.0.0"
 grpcio = { version = "^1.46.0", allow-prereleases = true }
 betterproto = { version = "2.0.0b4", allow-prereleases = true }
+nest-asyncio = "^1.5.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"

--- a/qdrant_client/__init__.py
+++ b/qdrant_client/__init__.py
@@ -1,3 +1,23 @@
 __version__ = '0.1.0'
 
 from .qdrant_client import QdrantClient
+
+
+def _in_ipython() -> bool:
+    """
+    Check whether we're in an ipython environment, including jupyter notebooks.
+    """
+    try:
+        eval('__IPYTHON__')
+    except NameError:
+        return False
+    else:  # pragma: no cover
+        return True
+
+
+if _in_ipython():  # pragma: no cover
+    # Python asyncio design is mediocre, it is not possible to await for a future, if there is another loop running.
+    # Ipython uses asyncio, which makes it impossible to run other async functions, so we need to monkey-patch it.
+    # It might be dangerous to do this in production, so we are doing it for Jupyter notebooks only.
+    import nest_asyncio
+    nest_asyncio.apply()

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -1067,7 +1067,8 @@ class QdrantClient:
                           payload: Optional[Iterable[dict]] = None,
                           ids: Optional[Iterable[types.PointId]] = None,
                           batch_size: int = 64,
-                          parallel: int = 1):
+                          parallel: int = 1,
+                          **kwargs):
         """Upload vectors and payload to the collection
 
         Args:
@@ -1098,6 +1099,7 @@ class QdrantClient:
                                                          payload=payload,
                                                          ids=ids,
                                                          batch_size=batch_size)
+        updater_kwargs.update(kwargs)
         if parallel == 1:
             updater = updater_class.start(**updater_kwargs)
             for _ in tqdm(updater.process(batches_iterator)):

--- a/qdrant_client/uploader/rest_uploader.py
+++ b/qdrant_client/uploader/rest_uploader.py
@@ -31,15 +31,15 @@ def upload_batch(openapi_client: SyncApis, collection_name: str, batch) -> bool:
 
 class RestBatchUploader(BaseUploader):
 
-    def __init__(self, uri, collection_name):
+    def __init__(self, uri, collection_name, **kwargs: Any):
         self.collection_name = collection_name
-        self.openapi_client = SyncApis(host=uri)
+        self.openapi_client = SyncApis(host=uri, **kwargs)
 
     @classmethod
     def start(cls, collection_name=None, uri="http://localhost:6333", **kwargs) -> 'RestBatchUploader':
         if not collection_name:
             raise RuntimeError("Collection name could not be empty")
-        return cls(uri=uri, collection_name=collection_name)
+        return cls(uri=uri, collection_name=collection_name, **kwargs)
 
     def process(self, items: Iterable[Any]) -> Iterable[Any]:
         for batch in items:


### PR DESCRIPTION
The batchers (REST & gRPC) are creating each a dedicated client for communicating with the server.

Those clients are not aware of the latest changes in https://github.com/qdrant/qdrant_client/pull/61 regarding the api-key, https & http2.

The batchers API need to evolve to accept additional arguments in order to have fully formed clients underneath.

So far this PR proposes to propagate the `kwargs` along the way for the `RestBatchUploader` but it gets a bit messy.
A similar approach is also necessary to create the channel of the `GrpcBatchUploader`.