### PR TITLE
Fix text schema type conversion (gRPC->REST)

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -215,6 +215,8 @@ class GrpcToRest:
             return rest.PayloadSchemaType.INTEGER
         elif model == grpc.PayloadSchemaType.Keyword:
             return rest.PayloadSchemaType.KEYWORD
+        elif model == grpc.PayloadSchemaType.Text:
+            return rest.PayloadSchemaType.TEXT
         else:
             raise ValueError(f"invalid PayloadSchemaType model: {model}")  # pragma: no cover
 


### PR DESCRIPTION
The `grpc.PayloadSchemaType.Text` was not correctly converted to the corresponding REST type. That was leading to an exception:

```ValueError: invalid PayloadSchemaType model: 5```