### PR TITLE
Add `prefix` optional argument

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -59,11 +59,16 @@ class QdrantClient:
                  prefer_grpc=False,
                  https=None,
                  api_key=None,
+                 prefix=None,
                  **kwargs):
         self._prefer_grpc = prefer_grpc
         self._grpc_port = grpc_port
         self._host = host
         self._port = port
+        self._prefix = prefix
+
+        if prefix is not None and len(prefix) > 0 and prefix[0] != '/':
+            self._prefix = f"/{prefix}"
 
         self._https = https
         self._api_key = api_key
@@ -89,7 +94,7 @@ class QdrantClient:
             self._rest_headers['api-key'] = api_key
             self._grpc_headers.append(('api-key', api_key))
 
-        self.rest_uri = f"http{'s' if self._https else ''}://{host}:{port}"
+        self.rest_uri = f"http{'s' if self._https else ''}://{host}:{port}{self._prefix if self._prefix is not None else ''}"
         self._rest_args = {
             "headers": self._rest_headers,
             "http2": http2,

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -49,6 +49,7 @@ class QdrantClient:
         prefer_grpc: If `true` - use gPRC interface whenever possible in custom methods.
         https: If `true` - use HTTPS(SSL) protocol. Default: `false`
         api_key: API key for authentication in Qdrant Cloud. Default: `None`
+        prefix: If not `None` - add `prefix` after `port` in the rest uri. Default: `None`
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -49,7 +49,10 @@ class QdrantClient:
         prefer_grpc: If `true` - use gPRC interface whenever possible in custom methods.
         https: If `true` - use HTTPS(SSL) protocol. Default: `false`
         api_key: API key for authentication in Qdrant Cloud. Default: `None`
-        prefix: If not `None` - add `prefix` after `port` in the rest uri. Default: `None`
+        prefix:
+            If defined, it specifies a string to concat at the end of the rest URI.
+            - If no `/` is defined at the beginning of `prefix`, it'll be added by default.
+            E.g: if `prefix=qdrant` and `host=example.com`, it will generate `http://example.com:6333/qdrant`
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -50,9 +50,9 @@ class QdrantClient:
         https: If `true` - use HTTPS(SSL) protocol. Default: `false`
         api_key: API key for authentication in Qdrant Cloud. Default: `None`
         prefix:
-            If defined, it specifies a string to concat at the end of the rest URI.
-            - If no `/` is defined at the beginning of `prefix`, it'll be added by default.
-            E.g: if `prefix=qdrant` and `host=example.com`, it will generate `http://example.com:6333/qdrant`
+            If not `None` - add `prefix` to the REST URL path.
+            Example: `service/v1` will result in `http://localhost:6333/service/v1/{qdrant-endpoint}` for REST API.
+            Default: `None`
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 


### PR DESCRIPTION
Hi 👋  I didn't find a contributing documentation but I took the freedom to create this PR so maybe you will agree to add this feature to the python client.

## Context
We would like to send requests to our Qdrant cluster on the same domain name as our API but with a prefix `/qdrant` for example (e.g. `api.inarix.com/qdrant`).

## Solution
I added an optional `prefix` argument to the constructor and merged it to the rest uri if it exists.

Feel free to tell me what I need to do to be accepted and merged 😄 