### PR TITLE
Fix `delete` missing return when HTTP

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -955,7 +955,7 @@ class QdrantClient:
         else:
             points_selector = self._try_argument_to_rest_selector(points_selector)
 
-            self.openapi_client.points_api.delete_points(
+            return self.openapi_client.points_api.delete_points(
                 collection_name=collection_name,
                 wait=wait,
                 points_selector=points_selector


### PR DESCRIPTION
I've added the missing return statement to the `QdrantClient.delete` method for when HTTP is used.