### PR TITLE
explicit timeout param

### DIFF
--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -73,7 +73,7 @@ def test_record_upload(prefer_grpc):
         for idx in range(NUM_VECTORS)
     )
 
-    client = QdrantClient(prefer_grpc=prefer_grpc)
+    client = QdrantClient(prefer_grpc=prefer_grpc, timeout=3.0)
 
     client.recreate_collection(
         collection_name=COLLECTION_NAME,


### PR DESCRIPTION
Related issue: https://github.com/qdrant/qdrant_client/issues/84

Added explicit `timeout` parameter to `QdrantClient`.
Parameter affects both REST and gRPC requests.