### PR TITLE
skip validation while converting scored points

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -334,7 +334,7 @@ class GrpcToRest:
 
     @classmethod
     def convert_scored_point(cls, model: grpc.ScoredPoint) -> rest.ScoredPoint:
-        return rest.ScoredPoint(
+        return rest.ScoredPoint.construct(
             id=cls.convert_point_id(model.id),
             payload=cls.convert_payload(model.payload),
             score=model.score,


### PR DESCRIPTION
This speeds up serialization from one second to 22ms in some cases